### PR TITLE
Added .gitignore to ignore DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Pretty straightforward and just sort of repo curating.

Mac DS_Store files are invisible on Mac, but become glaringly obvious in Windows and are present in the current release download of FactionFriend. So, I started with it and other dev files can be ignored as needed later on. This largely just helps keep it clean of the extraneous files.