### PR TITLE
Added Timewarped Badges to reputation prediction.

### DIFF
--- a/FFF_ItemInfo.lua
+++ b/FFF_ItemInfo.lua
@@ -1060,6 +1060,12 @@ FFF_ItemInfo = {
 				[25416] = 10,	-- Oshu'gun Crystal Fragment
 			},
 		},
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129945] = 1,	-- Commendation of the Consortium, Timewarped Badge purchase
+			}
+		},
 	},
 	[F.MAGHAR] = {
 		Warbeads = {
@@ -1110,6 +1116,12 @@ FFF_ItemInfo = {
 			items = {
 				[35188] = 15,	-- Nesingwary Lackey Ear
 			},
+		},
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129949] = 1,	-- Commendation of Cenarion Expedition, Timewarped Badge purchase
+			}
 		},
 	},
 	[F.SPOREGGAR] = {
@@ -1251,6 +1263,12 @@ FFF_ItemInfo = {
 				[25719] = 30,	-- Arakkoa Feather
 			},
 		},
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129951] = 1,	-- Commendation of Lower City, Timewarped Badge purchase
+			}
+		},
 	},
 	[F.NETHERWING] = {
 		GreatEggHunt = {
@@ -1340,6 +1358,13 @@ FFF_ItemInfo = {
 				[29425] = 10,	-- Mark of Kil'jaeden
 			},
 		},
+
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129946] = 1,	-- Commendation of The Sha'tar, Timewarped Badge purchase
+			}
+		},
 	},
 
 	-- Wrath of the Lich King factions
@@ -1358,6 +1383,12 @@ FFF_ItemInfo = {
 				[42780] = 10,	-- Relic of Ulduar
 			},
 		},
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129943] = 1,	-- Commendation of the Sons of Hodir, Timewarped Badge purchase
+			}
+		},
 	},
 	[F.EBON_BLADE] = {
 		ReadingTheBones = {
@@ -1366,6 +1397,12 @@ FFF_ItemInfo = {
 			items = {
 				[43089] = 15,	-- Vrykul Bones
 			},
+		},
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129941] = 1,	-- Commendation of The Ebonblade, Timewarped Badge purchase
+			}
 		},
 	},
 
@@ -1768,6 +1805,120 @@ FFF_ItemInfo = {
 			items = {
 				[120172] = 1,	-- Vileclaw's Claw
 			},
+		},
+	},
+
+	-- Old factions with only Timewalker turn-ins (Timewarped Badges)
+	[F.HONOR_HOLD] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129948] = 1,	-- Commendation of Honor Hold, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.ALLIANCE_VANGUARD] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129955] = 1,	-- Commendation of the Alliance Vanguard, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.ARGENT_CRUSADE] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129942] = 1,	-- Commendation of the Argent Crusade, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.DRAGONMAW] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[133150] = 1,	-- Commendation of the Dragonmaw Clan, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.EARTHEN_RING] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[133159] = 1,	-- Commendation of the Earthen Ring, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.GUARDIANS_HYJAL] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[133152] = 1,	-- Commendation of the Guardians of Hyjal, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.HORDE_EXPEDITION] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129954] = 1,	-- Commendation of the Horde Expedition, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.KEEPERS_OF_TIME] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129950] = 1,	-- Commendation of the Keepers of Time, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.KIRIN_TOR] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129940] = 1,	-- Commendation of the Kirin Tor, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.RAMKAHEN] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[133154] = 1,	-- Commendation of the Ramkahen, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.WILDHAMMER] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[133151] = 1,	-- Commendation of the Wildhammer Clan, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.WYRMREST] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129944] = 1,	-- Commendation of the Wyrmrest Accord, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.THERAZANE] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[133160] = 1,	-- Commendation of Therazane, Timewarped Badge purchase
+			}
+		},
+	},
+	[F.THRALLMAR] = {
+		TimewarpedCommendation = {
+			value = 500,
+			items = {
+				[129947] = 1,	-- Commendation of Thrallmar, Timewarped Badge purchase
+			}
 		},
 	},
 };


### PR DESCRIPTION
Changes for #11. Caveat to this PR -- I did this one blind. The Timewalking event is currently over and I didn't participate in it, so I have neither tokens nor commendation badges with which to test it, nor do I know when it will repeat (I'm not seeing future ones on the calendar). Ideally, someone with badges with which to test it (at least spot-checking) would be nice. That said, this is just adding data to the ItemInfo list, using the format already done, so as long as Wowhead's item IDs are accurate, it should work.

I grouped all of the factions that only have Timewarped Commendations at the bottom of the list, since this is going to expand as long as WoW gets expansions, which should make it easy to add to the list (since most of the WOD factions don't get any items that increase reputation).